### PR TITLE
perf(requirements): Non-old setuptools version in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup, find_packages
 from io import open
+from setuptools import find_packages
+from setuptools import setup
 
 version = '2.4.dev0'
 
@@ -29,7 +30,7 @@ setup(name='pyroma',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'setuptools',
+          'setuptools>=38.4.1',
           'docutils',
       ],
       entry_points={


### PR DESCRIPTION
### 1. Summary

Some machines can have old setuptools version, and pyroma can work incorrect.

For example, old setuptools version uses in AppVeyor and Circle CI at the time (28.8.0).

### 2. Behavior before pull-request

+ [**AppVeyor**](https://ci.appveyor.com/project/Kristinita/sashapyromadebugging/build/1.0.1),
+ [**Circle CI**](https://circleci.com/gh/Kristinita/SashaPyromaDebugging/1).

```bash
$ pyroma .

------------------------------
Checking .
Registered VCS backend: git
Registered VCS backend: hg
Registered VCS backend: svn
Registered VCS backend: bzr
Found nothing
------------------------------
Your package does not have name data!
Your package does not have version data!
The version number should be a string.
The package's version number does not comply with PEP-386 or PEP-440.
The package had no description!
The package's long_description is quite short.
Your package does not have classifiers data.
You should specify what Python versions you support.
Your package does not have keywords data.
Your package does not have author data.
Your package does not have author_email data.
Your package does not have url data.
Your package does not have license data.
You should specify license in classifiers.
You are using Setuptools or Distribute but do not specify if this package is zip_safe or not. You should specify it, as it defaults to True, which you probably do not want.
------------------------------
Final rating: 0/10
This cheese seems to contain no dairy products
------------------------------

pyroma . returned exit code 2
```

### 3. Behavior after pull request

If `pip install -U setuptools` in CI scripts:

+ [**AppVeyor**](https://ci.appveyor.com/project/Kristinita/sashapyromadebugging/build/1.0.2),
+ [**Circle CI**](https://circleci.com/gh/Kristinita/SashaPyromaDebugging/3).

```bash
$ pyroma .

------------------------------
Checking .
Registered VCS backend: git
Registered VCS backend: hg
Registered VCS backend: svn
Registered VCS backend: bzr
Found erichek
------------------------------
The package's long_description is quite short.
------------------------------
Final rating: 9/10
Cottage Cheese
------------------------------

```

Thanks.
