### PR TITLE
Adds .gitattributes to fix github rendered language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pyroma/testdata/* linguist-vendored


### PR DESCRIPTION
That's how it looks right now:
<img width="997" alt="Снимок экрана 2019-03-30 в 0 45 30" src="https://user-images.githubusercontent.com/4660275/55264376-29631c80-5285-11e9-85ce-e3679ab29b6f.png">

But, this repo has nothing to do with `html` and it is only used for tests.
To improve the general feel of this project I suggest to ignore `.html` files inside `testdata/`.
Here are the docs: https://github.com/github/linguist#using-gitattributes

I hope that you will like your awesome library to be marked as `python` 🙂 