### PR TITLE
Removed sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
   - python: 2.7
   - python: 3.6
   - python: 3.7
-    sudo: required
     dist: xenial
   - python: pypy
   - python: pypy3


### PR DESCRIPTION
sudo is no longer required - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration