### PR TITLE
Prettify autogeneration of classifiers.py

### DIFF
--- a/fetch_classifiers.py
+++ b/fetch_classifiers.py
@@ -46,16 +46,16 @@ def update_classifiers():
 
         out.write(b'''LICENSE_CODES = {\n''')
         for license, codes in license_map.items():
-            out.write(b'    "%s": set(["' % license)
+            out.write(b'    "%s": {"' % license)
             out.write(b'", "'.join(codes))
-            out.write(b'"]),\n')
+            out.write(b'"},\n')
         out.write(b'''}\n\n''')
 
         out.write(b'''CODE_LICENSES = {\n''')
         for code, licenses in code_map.items():
-            out.write(b'    "%s": set([\n        "' % code)
+            out.write(b'    "%s": {\n        "' % code)
             out.write(b'",\n        "'.join(licenses))
-            out.write(b'"]),\n')
+            out.write(b'"},\n')
         out.write(b'''}\n\n''')
 
 


### PR DESCRIPTION
Suggested in https://github.com/regebro/pyroma/pull/34#issuecomment-497642831

Alternatively, the code could be upgraded to 

```python
out.write(b'''LICENSE_CODES = {\n''')
for license, codes in license_map.items():
    out.write(b'    "%s": {\n' % license)
    for code in codes:
        out.write(b'        "%s",\n' % code)
    out.write(b'    },\n')
out.write(b'''}\n\n''')

out.write(b'''CODE_LICENSES = {\n''')
for code, licenses in code_map.items():
    out.write(b'    "%s": {\n' % code)
    for license in licenses:
        out.write(b'        "%s",\n' % license)
    out.write(b'    },\n')
out.write(b'''}\n\n''')
```

to much better address formatting, and uses lots of trailing commas to make diffs smaller!