### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - python: 2.7
   - python: 3.6
   - python: 3.7
-    dist: xenial
+  - python: 3.8
   - python: pypy
   - python: pypy3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   - python: 3.6
   - python: 3.7
   - python: 3.8
+  - python: 3.9-dev
   - python: pypy
   - python: pypy3
 install:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
         "License :: OSI Approved :: MIT License",
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Xenial is the default on Travis, no need for the exception.

Also test on Python 3.9-dev, now in alpha, full release in October.