### PR TITLE
Fixed pygments version resolution using new pip resolver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ setup(
     install_requires=[
         "setuptools",
         "docutils",
-        "pygments < 2.6",  # needed to keep supporting Python 2
+        # needed to keep supporting Python 2
+        "pygments < 2.6; python_version < '3'",
+        "pygments; python_version >= '3'",
     ],
     entry_points={
         "console_scripts": ["pyroma = pyroma:main"],


### PR DESCRIPTION
Hi,
after an update to the last version of pyroma (2.6.1) I have got a problem with [this changes in setup.py](https://github.com/regebro/pyroma/commit/a524ade9683ea1e9d100260ea308f1e4e9d7510e#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) and [new pip dependency resolver](https://pip.pypa.io/en/stable/user_guide/#resolver-changes-2020). So I made a small fix based on [setuptools](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies) [Environment Markers](https://www.python.org/dev/peps/pep-0508/#environment-markers)