### PR TITLE
Explicitly open text-mode files with UTF-8 to fix Windows issues and ensure correct cross-platform behavior

### DIFF
--- a/pyroma/distributiondata.py
+++ b/pyroma/distributiondata.py
@@ -19,10 +19,12 @@ def get_data(path):
         tempdir = tempfile.mkdtemp()
 
         if ext in (".bz2", ".tbz", "tb2", ".gz", ".tgz", ".tar"):
-            tarfile.open(name=path, mode="r:*").extractall(tempdir)
+            with tarfile.open(name=path, mode="r:*") as tar_file:
+                tar_file.extractall(tempdir)
 
         elif ext in (".zip", ".egg"):
-            zipfile.ZipFile(path, mode="r").extractall(tempdir)
+            with zipfile.ZipFile(path, mode="r") as zip_file:
+                zip_file.extractall(tempdir)
 
         else:
             raise ValueError("Unknown file type: " + ext)

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -119,7 +119,7 @@ def run_setup(script_name, script_args=None, stop_after="run"):
             sys.argv[0] = script_name
             if script_args is not None:
                 sys.argv[1:] = script_args
-            f = open(script_name)
+            f = open(script_name, encoding="UTF-8")
             try:
                 exec(f.read(), glocals, glocals)
             finally:

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -119,11 +119,8 @@ def run_setup(script_name, script_args=None, stop_after="run"):
             sys.argv[0] = script_name
             if script_args is not None:
                 sys.argv[1:] = script_args
-            f = open(script_name, encoding="UTF-8")
-            try:
+            with open(script_name, encoding="UTF-8") as f:
                 exec(f.read(), glocals, glocals)
-            finally:
-                f.close()
         finally:
             sys.argv = save_argv
             core._setup_stop_after = None

--- a/pyroma/testdata/complete/setup.py
+++ b/pyroma/testdata/complete/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 version = "1.0"
 
-with open("README.txt") as readme:
+with open("README.txt", encoding="UTF-8") as readme:
     long_description = readme.read()
 
 setup(

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -53,7 +53,9 @@ class FakeResponse:
         self.code = responsecode
 
     def read(self):
-        return open(self.filename, "rb").read()
+        with open(self.filename, "rb") as f:
+            file_contents = f.read()
+        return file_contents
 
 
 def urlopenstub(url):
@@ -92,7 +94,8 @@ class ProxyStub:
             __name__, os.path.join("testdata", "xmlrpcdata", dataname)
         )
         data = {}
-        exec(open(filename, encoding="UTF-8").read(), None, data)
+        with open(filename, encoding="UTF-8") as f:
+            exec(f.read(), None, data)
         self.args = data["args"]
         self.kw = data["kw"]
         self._data = data["data"]

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -92,7 +92,7 @@ class ProxyStub:
             __name__, os.path.join("testdata", "xmlrpcdata", dataname)
         )
         data = {}
-        exec(open(filename).read(), None, data)
+        exec(open(filename, encoding="UTF-8").read(), None, data)
         self.args = data["args"]
         self.kw = data["kw"]
         self._data = data["data"]


### PR DESCRIPTION
Previously, an `encoding` was not specified when `open`ing the `setup.py`, resulting in a platform- and user-environment-dependent encoding being selected; in particular, Windows defaults to the user's local code page, not UTF-8. This results in the `setup.py` not being readable on Windows (or in other cases where the user has selected a non-UTF-8 encoding) if it contains any non-ASCII characters, resulting in a crash. This PR prevents this by specifying `encoding="utf-8"`, as should be standard practice for the vast majority of cases for non-trivial cases of opening text-mode files.

In addition, it does the same several other places in the tests to ensure they work cross-platform as well, and also fixes several instances where a `with` context manager was not being used to open files/resources, resulting in `ResourceWarnings` and other potential downstream problems.

Fixes #28 