### PR TITLE
PR: Add Pre-Commit hook to enable integration with Pre-Commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: pyroma
+    name: Check package with Pyroma
+    description: Check how well a Python package conforms to best practices.
+    entry: pyroma
+    args: ["-d", "--min=10", "."]
+    language: python
+    pass_filenames: false
+    always_run: true

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ In all cases the output is similar::
     Cottage Cheese
     ------------------------------
 
+
 Tests
 -----
 
@@ -81,6 +82,22 @@ This is the list of checks that are currently performed:
 * If you are checking on a PyPI package, and not a local directory or
   local package, pyroma will check that you have uploaded a source
   distribution, and not just binary distributions.
+
+
+Version control integration
+---------------------------
+
+With `pre-commit <https://pre-commit.com>`_, pyroma can be run whenever you
+commit your work by adding the following to your ``.pre-commit-config.yaml``:
+
+.. code-block:: yaml
+
+    repos:
+    -   repo: https://github.com/regebro/pyroma
+        rev: "3.0.2"
+        hooks:
+        -   id: pyroma
+
 
 Credits
 -------


### PR DESCRIPTION
Adds a [Pre-Commit](https://pre-commit.com/index.html) hook to the repo to make it easy for users to automatically check that their project conforms to the standards whenever they commit, push, etc. Also adds a short section to the readme explaining this, following the general pattern of other hooks supporting pre-commit. 

Once merged and `3.0.2` is released (if that doesn't end up being the next release, the tag in the hook boilerplate should be revised), a PR should be submitted to [the pre-commit.com repo](https://github.com/pre-commit/pre-commit.com) adding pyroma to the [list of hooks](https://pre-commit.com/hooks.html). All it requires is pasting the repo URL in [`all-repos.yaml`](https://github.com/pre-commit/pre-commit.com/blob/master/all-repos.yaml) and the tooling does the rest.