### PR TITLE
Simplify opening setup.py and fix obsolete warn

### DIFF
--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -120,12 +120,7 @@ def run_setup(script_name, script_args=None, stop_after="run"):
             sys.argv[0] = script_name
             if script_args is not None:
                 sys.argv[1:] = script_args
-
-            # Find the encoding
-            with open(script_name, "rb") as f:
-                encoding = tokenize.detect_encoding(f.readline)[0]
-
-            with open(script_name, "rt", encoding=encoding) as f:
+            with tokenize.open(script_name) as f:
                 exec(f.read(), glocals, glocals)
         finally:
             sys.argv = save_argv

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -126,7 +126,7 @@ def run_setup(script_name, script_args=None, stop_after="run"):
             sys.argv = save_argv
             core._setup_stop_after = None
     except Exception:
-        logging.warn("Exception when running setup.", exc_info=True)
+        logging.warning("Exception when running setup.", exc_info=True)
 
     if core._setup_distribution is None:
         raise RuntimeError(


### PR DESCRIPTION
Good thinking to use `tokenize` in commit 936720b to do the encoding detect. Given I don't think I've ever seen an real-life example of a Python package's setup.py in an obsolete (i.e. non-UTF-8-compatible) source encoding that actually had an intentional encoding marker and forgot there was a simple way to address that using `tokenize`, I didn't go out of my way to address that, but since there's a formally specified way, may as well,

However, as a followup to PR #56 . this can actually be made simpler, more robust and more efficient by replacing the whole thing with `tokenize.open()` as recommended by the [tokenize docs](https://docs.python.org/3/library/tokenize.html#tokenize.detect_encoding)

> Use open() to open Python source files: it uses detect_encoding() to detect the file encoding.

And low and behold, this PR does exactly that!

Also, it fixes an adjacent line which uses the [long-obsolete, undocumented](https://docs.python.org/3/library/logging.html#logging.warning) `logging.warn()` method rather than the correct `logging.warning()` (this is the only use in the codebase); I made this as a separate commit for clarity since I assume you'll just squash it when you merge.