### PR TITLE
Add --quiet option to output only the rating

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -16,6 +16,8 @@ Changelog
 
 - Some more code cleanup/modernization [CAM Gerlach]
 
+- Added --quiet option to output only the rating [Hugo van Kemenade]
+
 
 3.1 (2021-03-06)
 ----------------

--- a/pyroma/__init__.py
+++ b/pyroma/__init__.py
@@ -69,6 +69,14 @@ def main():
         default=False,
         help="Run pyroma on a package on PyPI",
     )
+    parser.add_option(
+        "-q",
+        "--quiet",
+        dest="quiet",
+        action="store_true",
+        default=False,
+        help="Output only the rating",
+    )
 
     (options, args) = parser.parse_args()
 
@@ -98,13 +106,17 @@ def main():
     elif options.file:
         mode = "file"
 
-    rating = run(mode, argument)
+    rating = run(mode, argument, options.quiet)
     if rating < options.min:
         sys.exit(2)
     sys.exit(0)
 
 
-def run(mode, argument):
+def run(mode, argument, quiet=False):
+
+    if quiet:
+        logger = logging.getLogger()
+        logger.disabled = True
 
     logging.info("-" * 30)
     logging.info("Checking " + argument)
@@ -133,5 +145,9 @@ def run(mode, argument):
     logging.info("Final rating: " + str(rating[0]) + "/10")
     logging.info(ratings.LEVELS[rating[0]])
     logging.info("-" * 30)
+
+    if quiet:
+        logger.disabled = False
+        logging.info(rating[0])
 
     return rating[0]


### PR DESCRIPTION
Fixes https://github.com/regebro/pyroma/issues/47.

Demo:

```console
$ pyroma .
------------------------------
Checking .
Found pyroma
------------------------------
Final rating: 10/10
Your cheese is so fresh most people think it's a cream: Mascarpone
------------------------------
$ pyroma . --quiet
10
$
```