### PR TITLE
Make pyroma a runnable module

### DIFF
--- a/pyroma/__main__.py
+++ b/pyroma/__main__.py
@@ -1,0 +1,5 @@
+from . import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a suitable `__main__.py` file to `pyroma`. This allows one to run `pyroma` as a module
```
python -m pyroma ...
```

Although the `python -m` syntax may seem verbose and redundant, it is useful for scripting/automation purposes as it allows you to ensure, which python environment/version is being used.