### PR TITLE
Check if author_email field contains author name (fix #77)

### DIFF
--- a/pyroma/ratings.py
+++ b/pyroma/ratings.py
@@ -258,11 +258,8 @@ class Author(FieldTest):
     def test(self, data):
         """Check if author_email field contains author name."""
         email = data.get("author_email")
-        if email is not None:
-            # For example "Author Name <author.name@email.com>".
-            return "<" in email
-        else:
-            return super().test(data)
+        # Pass if author name in email, e.g. "Author Name <author@example.com>"
+        return True if email and "<" in email else super().test(data)
 
 
 class AuthorEmail(FieldTest):

--- a/pyroma/ratings.py
+++ b/pyroma/ratings.py
@@ -255,6 +255,15 @@ class Author(FieldTest):
     weight = 100
     field = "author"
 
+    def test(self, data):
+        """Check if author_email field contains author name."""
+        email = data.get("author_email")
+        if email is not None:
+            # For example "Author Name <author.name@email.com>".
+            return "<" in email
+        else:
+            return super().test(data)
+
 
 class AuthorEmail(FieldTest):
     weight = 100

--- a/pyroma/testdata/pep621/README.txt
+++ b/pyroma/testdata/pep621/README.txt
@@ -1,0 +1,22 @@
+Complete
+========
+
+This is a test package for pyroma that is supposed to have a complete
+set of metadata and also runnable tests. It should score the maximum possible
+on package tests.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor, neque at
+dignissim condimentum, libero est dictum dolor, sit amet tempor urna diam eget
+velit. Suspendisse at odio quam, ut vestibulum ipsum. Nulla facilisi. Nullam
+nunc dolor, tempus in vulputate id, fringilla eget metus. Pellentesque nulla
+nisl, imperdiet ac vulputate non, commodo tincidunt purus. Aenean sollicitudin
+orci eget diam dignissim scelerisque. Donec quis neque nisl, eu adipiscing
+velit. Aenean convallis ante sapien. Etiam vitae viverra libero. Nullam ac
+ligula erat. Aliquam pellentesque, est eget faucibus pharetra, urna orci rhoncus
+nisi, adipiscing elementum libero lectus ut odio. Duis tincidunt mi quam, quis
+interdum enim. Nunc sed urna urna, id lacinia turpis. Quisque malesuada, velit
+ut tincidunt lacinia, dolor augue varius velit, in ultrices lectus enim et
+dolor. Fusce augue eros, aliquet ac dapibus at, tincidunt vitae leo. Lorem ipsum
+dolor sit amet, consectetur adipiscing elit. Vivamus sapien neque, fermentum sed
+ultrices sit amet, fermentum nec est. Pellentesque imperdiet enim nec velit
+posuere id dignissim massa molestie.

--- a/pyroma/testdata/pep621/pyproject.toml
+++ b/pyroma/testdata/pep621/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "pyroma_pep621_test_pkg"
+version = "1.0"
+description = "This is a test package for pyroma"
+readme = "README.txt"
+authors = [{name = "Lennart Regebro", email = "regebro@gmail.com"}]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 2.6",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.1",
+    "Programming Language :: Python :: 3.2",
+    "Programming Language :: Python :: 3.3",
+    "License :: OSI Approved :: MIT License",
+]
+keywords = [
+    "pypi",
+    "quality",
+    "example",
+]
+urls = {Homepage = "https://github.com/regebro/pyroma"}
+
+[tool.setuptools]
+include-package-data = false

--- a/pyroma/testdata/pep621/pyroma_pep621_test_pkg/__init__.py
+++ b/pyroma/testdata/pep621/pyroma_pep621_test_pkg/__init__.py
@@ -1,0 +1,4 @@
+"""This is a test package for pyroma."""
+
+__version__ = "1.0.0"
+

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -146,6 +146,16 @@ class RatingsTest(unittest.TestCase):
             ),
         )
 
+    def test_pep621(self):
+        rating = self._get_file_rating("pep621")
+        self.assertEqual(
+            rating,
+            (
+                10,
+                [],
+            ),
+        )
+
     def test_minimal(self):
         rating = self._get_file_rating("minimal")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ test =
     pytest
     pytest-cov
     setuptools>=60
-    flit>=3.4,<4
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ test =
     pytest
     pytest-cov
     setuptools>=60
+    flit>=3.4,<4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This test is a bit naive, and will yield a false positive for emails like:
`"very.(),:;<>[]\".VERY.\"very@\\ \"very\".unusual"@strange.example.com`
which is a valid email address (though I'm not sure if pyproject.toml supports it).

Good enough, or a more robust approach needed?

Fix #77