### PR TITLE
Split linting out to separate CI job and use pre-commit to run it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+# Run the linting suite for the pyroma package
+# Based on https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Lint package
+
+on: [pull_request, push]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    name: Run pre-commit
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-      - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
       - name: Install package
         run: pip install -e .[test]
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-      - name: Install tools
-        run: pip install flake8 black
-      - name: Run black
-        run: black --quiet --check .
-      - name: Run flake8
-        run: flake8 .
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.0
       - name: Install package
         run: pip install -e .[test]
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
 -   repo: https://github.com/regebro/pyroma


### PR DESCRIPTION
As discussed in #84 , instead of manually adding and configuring linting, we can instead use just run our existing pre-commit checks via the pre-commit action, which avoids duplication, ensures consistancy and shows the output of all linters, not just the firs to fail.

Furthermore, better to run them in a separate job, so that it runs faster, more efficiently (since it only needs to run on one job in the matrix) and doesn't block seeing the test output as well.

I also autoupdated to the latest hook versions, while we're at it.