### PR TITLE
Silence noisy build backend output when building metadata

### DIFF
--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -5,6 +5,7 @@ import email.policy
 import logging
 import os
 import pathlib
+import pep517
 import sys
 import tempfile
 import tokenize
@@ -24,7 +25,7 @@ METADATA_MAP = {
 
 def get_build_data(path):
     with tempfile.TemporaryDirectory() as tempdir:
-        metadata_dir = build.ProjectBuilder(str(path)).prepare("wheel", tempdir)
+        metadata_dir = build.ProjectBuilder(str(path), runner=pep517.quiet_subprocess_runner).prepare("wheel", tempdir)
         with open(pathlib.Path(metadata_dir) / "METADATA", "rb") as metadata_file:
             metadata = email.message_from_binary_file(metadata_file, policy=email.policy.compat32)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,11 +33,12 @@ packages = find:
 package_dir =
     = .
 install_requires =
-    setuptools>=61.0.0
+    build
     docutils
+    pep517
     pygments
     requests
-    build
+    setuptools>=61.0.0
     trove-classifiers>=2022.6.26
     wheel
 


### PR DESCRIPTION
As reported by @wesleybl on #86 , the full (often verbose, especially in the case of Setuptools) build backend output is shown when just extracting the metadata from the project, which is noisy and distracting, taking away from the carefully curated pyroma output. Now, no build backend output is shown (except for errors). This to @wesleybl for doing all the work to report this and propose a solution! If you could somehow share your commit email, I'd ensure the commit was `Co-authored-by:` you.

Fixes #86 