### PR TITLE
Updated GitHub Actions to Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.10', '3.11-dev', 'pypy-3.7']
+        python-version: ['3.7', '3.11', 'pypy-3.7']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
I presume that the intention is for GitHub Actions to test the oldest and latest supported CPython.