### PR TITLE
Avoid tar directory traversal on sdist extract to fix CVE-2007-4559

### DIFF
--- a/pyroma/distributiondata.py
+++ b/pyroma/distributiondata.py
@@ -15,8 +15,8 @@ from pyroma import projectdata
 
 def _safe_extract_tar(tar, path=".", members=None, numeric_owner=False):
     """Safely extract a tar w/o traversing parent dirs to fix CVE-2007-4559."""
+    root = pathlib.Path(path).resolve()
     for member in tar.getmembers():
-        root = pathlib.Path(path).resolve()
         member_path = (root / member.name).resolve()
         if root not in member_path.parents:
             raise Exception(f"Attempted path traversal in tar file {tar.name!r}")


### PR DESCRIPTION
This fixes the tar directory traversal issue with Python's stdlib `tarfile` module's `extractall` function, replacing #89 and adapted from what we did in spyder-ide/spyder-kernels#428 , but greatly simplifying the implementation using `pathlib` (and making a few other tweaks to confirm with `pyroma`'s style and practices).

Closes #89 