### PR TITLE
Fall back to isolated mode for metadata build & simplify codepath

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,18 @@ Changelog
 4.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fall back to installing project's build backend in an isolated environment
+  if a compatible version isn't installed in the current env [CAM-Gerlach]
+
+- Fix metadata extraction failure when project ``long_description`` is included
+  as a header rather than a payload in the ``METADTA`` file [CAM-Gerlach]
+
+- Add a fallback to restore compatibility with Setuptools <61 [CAM-Gerlach]
+
+- Fix tests failing due to invalid versions on Setuptools >=66 [CAM-Gerlach]
+
+- Add ``python_requires``, update classifiers, add implicit dependencies
+  and remove unused deps in Pyroma's own packaging metadata [CAM-Gerlach]
 
 
 4.1 (2022-11-24)
@@ -25,7 +36,6 @@ Changelog
 - Now follows black and flake8 rules
 
 - Check if author_email field contains author name [bessman]
-
 
 
 4.0 (2022-04-14)

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -1,13 +1,9 @@
 # Extracts information from a project that has a distutils setup.py file.
-import build
-import email
-import email.policy
+import build.util
 import logging
 import os
 import pathlib
-import pep517
 import sys
-import tempfile
 import tokenize
 from copy import copy
 from distutils import core
@@ -25,11 +21,7 @@ METADATA_MAP = {
 
 
 def get_build_data(path):
-    with tempfile.TemporaryDirectory() as tempdir:
-        metadata_dir = build.ProjectBuilder(str(path), runner=pep517.quiet_subprocess_runner).prepare("wheel", tempdir)
-        with open(pathlib.Path(metadata_dir) / "METADATA", "rb") as metadata_file:
-            metadata = email.message_from_binary_file(metadata_file, policy=email.policy.compat32)
-
+    metadata = build.util.project_wheel_metadata(path, isolated=True)
     if "Description" not in metadata.keys():
         # Having the description as a payload tends to add two newlines, we clean that up here:
         long_description = metadata.get_payload().strip() + "\n"

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -35,10 +35,11 @@ def build_metadata(path, isolated=None):
 
 
 def map_metadata_keys(metadata):
+    data = {}
     if "Description" not in metadata.keys():
         # Having the description as a payload tends to add two newlines, we clean that up here:
         long_description = metadata.get_payload().strip() + "\n"
-        data = {"long_description": long_description}
+        data["long_description"] = long_description
 
     for key in set(metadata.keys()):
         value = metadata.get_all(key)

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -8,7 +8,11 @@ import sys
 import tokenize
 from copy import copy
 from distutils import core
-from setuptools import config
+
+try:  # config renamed to config.setupcfg on Setuptools >=61 adding pyproject.toml support
+    from setuptools.config.setupcfg import read_configuration
+except ModuleNotFoundError:
+    from setuptools.config import read_configuration
 
 METADATA_MAP = {
     "summary": "description",
@@ -61,7 +65,7 @@ def get_build_data(path, isolated=None):
 
 def get_setupcfg_data(path):
     # Note: By default, setup.cfg will read the pyroma.git/setup.cfg - forcing explicit setup.cfg under test's file path
-    data = config.setupcfg.read_configuration(str(pathlib.Path(path) / "setup.cfg"))
+    data = read_configuration(str(pathlib.Path(path) / "setup.cfg"))
     metadata = data["metadata"]
     return metadata
 
@@ -256,9 +260,7 @@ def get_setuppy_data(path):
 
             elif os.path.isfile("setup.cfg"):
                 try:
-                    from setuptools import config
-
-                    data = config.read_configuration("setup.cfg")
+                    data = read_configuration("setup.cfg")
                     metadata = data["metadata"]
                     metadata["_setuptools"] = True
                 except Exception as e:

--- a/pyroma/testdata/custom_test/setup.py
+++ b/pyroma/testdata/custom_test/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from setuptools.command.test import test
 
-version = "0.0foo"
+version = "0.0.1"
 
 
 class CustomTest(test):

--- a/pyroma/testdata/minimal/setup.py
+++ b/pyroma/testdata/minimal/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.0foo"
+version = "0.0.1"
 
 setup(
     name="minimal",

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -169,7 +169,6 @@ class RatingsTest(unittest.TestCase):
             (
                 2,
                 [
-                    "The package's version number does not comply with PEP-386 or PEP-440.",
                     "The package's description should be longer than 10 characters.",
                     "The package's long_description is quite short.",
                     "Your package does not have classifiers data.",
@@ -228,7 +227,6 @@ class RatingsTest(unittest.TestCase):
             (
                 2,
                 [
-                    "The package's version number does not comply with PEP-386 or PEP-440.",
                     "The package's description should be longer than 10 characters.",
                     "The package's long_description is quite short.",
                     "Your package does not have classifiers data.",

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,13 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 keywords = pypi, quality, testing
 author = Lennart Regebro
@@ -32,6 +32,7 @@ include_package_data = True
 packages = find:
 package_dir =
     = .
+python_requires = >=3.7
 install_requires =
     build
     docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,8 @@ package_dir =
     = .
 python_requires = >=3.7
 install_requires =
-    build
+    build>=0.7.0
     docutils
-    pep517
     pygments
     requests
     setuptools>=61.0.0
@@ -51,7 +50,6 @@ test =
     pytest
     pytest-cov
     setuptools>=60
-    flit >=3.4,<4
     zest.releaser[recommended]
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     docutils
     pygments
     requests
-    setuptools>=61.0.0
+    setuptools>=42
     trove-classifiers>=2022.6.26
     wheel
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,11 @@ python_requires = >=3.7
 install_requires =
     build>=0.7.0
     docutils
+    packaging
     pygments
     requests
     setuptools>=42
     trove-classifiers>=2022.6.26
-    wheel
 
 [options.packages.find]
 where = .

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,6 @@ where = .
 
 [options.extras_require]
 test =
-    pytest
-    pytest-cov
     setuptools>=60
     zest.releaser[recommended]
 
@@ -69,7 +67,6 @@ testpaths =
 [check-manifest]
 ignore =
   .pre-commit-hooks.yaml
-  fetch_classifiers.py
 
 [zest.releaser]
 create-wheel = yes


### PR DESCRIPTION
Currently, as discussed in https://github.com/regebro/pyroma/pull/78#issuecomment-1295415812 , Pyroma still requires the user's build backend and any other required build deps to be installed in the same env Pyroma itself is installed in order to work. To work around this, we can have `build` fall back to using an isolated build environment with the project's `build-system.requires` build dependencies automatically installed, which will work with any build backend (including legacy setup.py builds, as it installs Setuptools by default if no pyproject build system is specified).

This retains the efficiency and (in some cases) backward compatibility of the existing non-isolated approach (if users have their backend already installed in the env Pyroma is installed), while now working reliably for any PEP 517 backend without users having to manually install their build dependencies. Both code paths are exercised in the test suite, as it contains test projects with both installed (Setuptools) and not-installed (Flit) build backends.

Additionally, this takes advantage of using the newer (Build 0.7.0) helper function `build.util.project_wheel_metadata`, which simplifies the metadata build code down to a single line, and makes it more efficient and reliable in the process, running virtually instantly in non-isolated envs.

Finally, I've updated the `setup.cfg` runtime and test dependencies accordingly, as well as added a `python_requires` and updated the trove classifiers to reflect the currently supported minimum Python version.

EDIT: Also, as discussed in https://github.com/hugovk/pyroma/commit/26dd7cd8cbf43b331802d74f2326dcd9b6a02e9e#commitcomment-91750223 , I've avoided the need to tightly constrain setuptools at runtime, and instead added a simple graceful fallback

EDIT 2: And as discussed in https://github.com/regebro/pyroma/pull/72#discussion_r1037805258 , removed the accidentally-added pytest* test extra dependencies as well as the outdated `fetch_classifiers` MANIFEST exclude.

EDIT 3: Also removed `wheel` as a required dependency, as it is not directly required by `pyroma` (and instead required if needed by `build` and `setuptools`, as an implementation detail), while adding `packaging`, since it is used directly but was never added as an explicit dependency (but just merely happens to be satisfied transitively).

EDIT 4: Fix test failures with Setuptools >66.0.0 due to invalid versions making packages unbuildable (see #95)

Fix #64 
Fix #95 