### PR TITLE
Add support for Python 3.13 and drop EOL 3.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@
 
 name: Lint package
 
-on: [pull_request, push]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    name: Run package tests
+    name: Tests
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 
 name: Test package
 
-on: [pull_request, push]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.13', 'pypy-3.10']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.12', 'pypy-3.10']
+        python-version: ['3.9', '3.12', 'pypy-3.10']
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.12', 'pypy-3.10']
+        python-version: ['3.9', '3.13', 'pypy-3.10']
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 24.10.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/regebro/pyroma

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -278,7 +278,7 @@ class PyPITest(unittest.TestCase):
     @unittest.mock.patch("pyroma.pypidata._get_project_data")
     def test_distribute(self, projectdatamock):
         datafile = resource_filename(__name__, os.path.join("testdata", "jsondata", "distribute.json"))
-        with open(datafile, "rt", encoding="UTF-8") as file:
+        with open(datafile, encoding="UTF-8") as file:
             projectdatamock.return_value = json.load(file)
 
         proxystub.set_debug_context("distributedata.py", xmlrpclib.ServerProxy, False)
@@ -308,7 +308,7 @@ class PyPITest(unittest.TestCase):
     @unittest.mock.patch("pyroma.pypidata._get_project_data")
     def test_complete(self, projectdatamock):
         datafile = resource_filename(__name__, os.path.join("testdata", "jsondata", "complete.json"))
-        with open(datafile, "rt", encoding="UTF-8") as file:
+        with open(datafile, encoding="UTF-8") as file:
             projectdatamock.return_value = json.load(file)
 
         proxystub.set_debug_context("completedata.py", xmlrpclib.ServerProxy, False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -32,7 +31,7 @@ include_package_data = True
 packages = find:
 package_dir =
     = .
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     build>=0.7.0
     docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy


### PR DESCRIPTION
Also:

* Allow triggering manual builds via GitHub UI
* Bump GitHub Actions
* Bump pre-commit
* Run all jobs even if one fails
* Shorten name so full job info is shown

Windows/PyPy is failing because a dependency is missing a wheel, but that's also the case in `master`.