### PR TITLE
Allow private classifiers

### DIFF
--- a/pyroma/ratings.py
+++ b/pyroma/ratings.py
@@ -216,7 +216,7 @@ class ClassifierVerification(BaseTest):
         self._incorrect = []
         classifiers = data.get("classifiers", [])
         for classifier in classifiers:
-            if classifier not in CLASSIFIERS:
+            if classifier not in CLASSIFIERS and not classifier.startswith("Private :: "):
                 self._incorrect.append(classifier)
         if self._incorrect:
             return False

--- a/pyroma/testdata/private_classifier/README.txt
+++ b/pyroma/testdata/private_classifier/README.txt
@@ -1,0 +1,22 @@
+Complete
+========
+
+This is a test package for pyroma that is supposed to have a complete
+set of metadata and also runnable tests. It should score the maximum possible
+on package tests.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor, neque at
+dignissim condimentum, libero est dictum dolor, sit amet tempor urna diam eget
+velit. Suspendisse at odio quam, ut vestibulum ipsum. Nulla facilisi. Nullam
+nunc dolor, tempus in vulputate id, fringilla eget metus. Pellentesque nulla
+nisl, imperdiet ac vulputate non, commodo tincidunt purus. Aenean sollicitudin
+orci eget diam dignissim scelerisque. Donec quis neque nisl, eu adipiscing
+velit. Aenean convallis ante sapien. Etiam vitae viverra libero. Nullam ac
+ligula erat. Aliquam pellentesque, est eget faucibus pharetra, urna orci rhoncus
+nisi, adipiscing elementum libero lectus ut odio. Duis tincidunt mi quam, quis
+interdum enim. Nunc sed urna urna, id lacinia turpis. Quisque malesuada, velit
+ut tincidunt lacinia, dolor augue varius velit, in ultrices lectus enim et
+dolor. Fusce augue eros, aliquet ac dapibus at, tincidunt vitae leo. Lorem ipsum
+dolor sit amet, consectetur adipiscing elit. Vivamus sapien neque, fermentum sed
+ultrices sit amet, fermentum nec est. Pellentesque imperdiet enim nec velit
+posuere id dignissim massa molestie.

--- a/pyroma/testdata/private_classifier/pyproject.toml
+++ b/pyroma/testdata/private_classifier/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"

--- a/pyroma/testdata/private_classifier/setup.cfg
+++ b/pyroma/testdata/private_classifier/setup.cfg
@@ -1,0 +1,22 @@
+[metadata]
+name = private_classifier
+version = 1.0
+description = A project with a private classifier
+long_description = file: README.txt
+author = Lennart Regebro
+author_email = regebro@gmail.com
+url = https://example.com
+classifiers =
+    Development Status :: 6 - Mature
+    Operating System :: OS Independent
+    Private :: Do Not Upload
+    Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.1
+    Programming Language :: Python :: 3.2
+    Programming Language :: Python :: 3.3
+    License :: OSI Approved :: MIT License
+keywords =
+    private
+[options]
+python_requires = >=2.6

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -258,6 +258,10 @@ class RatingsTest(unittest.TestCase):
             ),
         )
 
+    def test_private_classifier(self):
+        rating = self._get_file_rating("private_classifier")
+        self.assertEqual(rating, (10, []))
+
     def test_markdown(self):
         # Markdown and text shouldn't get ReST errors
         testdata = COMPLETE.copy()


### PR DESCRIPTION
Fixes https://github.com/regebro/pyroma/issues/101.

The new test case's `setup.cfg` contains `Private :: Do Not Upload` which on `master` gives:

```
Some of your classifiers are not standard classifiers:
Private :: Do Not Upload
```