### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/pyroma/__init__.py
+++ b/pyroma/__init__.py
@@ -74,6 +74,7 @@ def skip_tests(arg):
 
 def main():
     parser = ArgumentParser()
+    parser.color = True
     parser.add_argument(
         "package", help="A python package, can be a directory, a distribution file or a PyPI package name."
     )


### PR DESCRIPTION
Re: https://docs.python.org/3.14/library/argparse.html#color

Before

<img width="749" height="249" alt="image" src="https://github.com/user-attachments/assets/e2d3f5ea-b9a6-40b5-ba00-44e4bf6dc2c2" />


After

<img width="741" height="245" alt="image" src="https://github.com/user-attachments/assets/0a0d22a3-2035-49e9-b1e3-176f829693a5" />
