### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.13', 'pypy-3.10']
+        python-version: ['3.9', '3.14', 'pypy-3.11']
 
     steps:
       - name: Checkout
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy


### PR DESCRIPTION
Python 3.14 is in beta and almost at release candidate.

The 3.14 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-14-0-beta-4-is-here/98092):

> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.14*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Tuesday 2025-07-22). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.14 as possible during the beta phase.
> 
> This includes creating pre-release wheels for 3.14, as it helps other projects to do their own testing. However, we recommend that your regular production releases wait until 3.14.0rc1, to avoid the risk of ABI breaks.

Also switch CI from pypy3.10 to pypy3.11, which is the only 3.x PyPy supports: https://pypy.org/posts/2025/07/pypy-v7320-release.html
