### PR TITLE
Add API to retrieve project metadata from an installed package.

### DIFF
--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -4,6 +4,7 @@ import build.util
 import os
 import pathlib
 import re
+from importlib.metadata import metadata
 
 from setuptools.config.setupcfg import read_configuration
 from distutils.errors import DistutilsFileError
@@ -47,6 +48,10 @@ def build_metadata(path, isolated=None):
         # metadata from PyPI, we just couldn't get the additional build data.
         return {"_wheel_build_failed": True}
 
+    return normalize_metadata(metadata)
+
+
+def normalize_metadata(metadata):
     # As far as I can tell, we can't trust that the builders normalize the keys,
     # so we do it here. Definitely most builders do not lower case them, which
     # Core Metadata Specs recommend.
@@ -70,6 +75,11 @@ def build_metadata(path, isolated=None):
         if description:
             data["description"] = description + "\n"
     return data
+
+
+def installed_metadata(name):
+    """Retrieve the metadata for an package that is installed in the environment."""
+    return normalize_metadata(metadata(name))
 
 
 def get_build_data(path, isolated=None):

--- a/pyroma/projectdata.py
+++ b/pyroma/projectdata.py
@@ -40,7 +40,7 @@ def wheel_metadata(path, isolated=None):
 
 def build_metadata(path, isolated=None):
     try:
-        metadata = wheel_metadata(path, isolated)
+        data = wheel_metadata(path, isolated)
     except build.BuildBackendException:
         # The backend failed spectacularily. This happens with old packages,
         # when we can't build a wheel. It's not always a fatal error. F ex, if
@@ -48,16 +48,16 @@ def build_metadata(path, isolated=None):
         # metadata from PyPI, we just couldn't get the additional build data.
         return {"_wheel_build_failed": True}
 
-    return normalize_metadata(metadata)
+    return normalize_metadata(data)
 
 
-def normalize_metadata(metadata):
+def normalize_metadata(data):
     # As far as I can tell, we can't trust that the builders normalize the keys,
     # so we do it here. Definitely most builders do not lower case them, which
     # Core Metadata Specs recommend.
-    data = {}
-    for key in set(metadata.keys()):
-        value = metadata.get_all(key)
+    normalized = {}
+    for key in set(data.keys()):
+        value = data.get_all(key)
         key = normalize(key)
 
         if len(value) == 1:
@@ -66,15 +66,15 @@ def normalize_metadata(metadata):
                 # XXX This is also old behavior that may not hjappen any more.
                 continue
 
-        data[key] = value
+        normalized[key] = value
 
-    if "description" not in data.keys():
+    if "description" not in normalized.keys():
         # XXX I *think* having the description as a payload doesn't happen anymore, but I haven't checked.
         # Having the description as a payload tends to add two newlines, we clean that up here:
-        description = metadata.get_payload().strip()
+        description = data.get_payload().strip()
         if description:
-            data["description"] = description + "\n"
-    return data
+            normalized["description"] = description + "\n"
+    return normalized
 
 
 def installed_metadata(name):

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -341,23 +341,26 @@ class ProjectDataTest(unittest.TestCase):
         # Verify some key metadata
         self.assertEqual(data["name"], "pyroma")
         self.assertEqual(data["summary"], "Test your project's packaging friendliness")
-        self.assertEqual(data["classifier"], [
-            "Development Status :: 5 - Production/Stable",
-            "Intended Audience :: Developers",
-            "License :: OSI Approved :: MIT License",
-            "Operating System :: OS Independent",
-            "Programming Language :: Python",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-            "Programming Language :: Python :: 3.14",
-            "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: Implementation :: CPython",
-            "Programming Language :: Python :: Implementation :: PyPy",
-        ])
+        self.assertEqual(
+            data["classifier"],
+            [
+                "Development Status :: 5 - Production/Stable",
+                "Intended Audience :: Developers",
+                "License :: OSI Approved :: MIT License",
+                "Operating System :: OS Independent",
+                "Programming Language :: Python",
+                "Programming Language :: Python :: 3",
+                "Programming Language :: Python :: 3.9",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.11",
+                "Programming Language :: Python :: 3.12",
+                "Programming Language :: Python :: 3.13",
+                "Programming Language :: Python :: 3.14",
+                "Programming Language :: Python :: 3 :: Only",
+                "Programming Language :: Python :: Implementation :: CPython",
+                "Programming Language :: Python :: Implementation :: PyPy",
+            ],
+        )
         self.assertEqual(data["keywords"], "pypi,quality,testing")
         self.assertEqual(data["author"], "Lennart Regebro")
         self.assertEqual(data["author-email"], "regebro@gmail.com")

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -366,7 +366,7 @@ class ProjectDataTest(unittest.TestCase):
         self.assertEqual(data["license-file"], "LICENSE.txt")
         self.assertEqual(data["project-url"], "Source Code, https://github.com/regebro/pyroma")
         self.assertEqual(data["provides-extra"], "test")
-        self.assertEqual(data["requires-python"], "3.9")
+        self.assertEqual(data["requires-python"], ">=3.9")
 
 
 class DistroDataTest(unittest.TestCase):

--- a/pyroma/tests.py
+++ b/pyroma/tests.py
@@ -334,6 +334,40 @@ class ProjectDataTest(unittest.TestCase):
         del data["_path"]  # This changes, so I just ignore it
         self.assertEqual(data, COMPLETE)
 
+    def test_installed(self):
+        # pyroma must be installed in the test environment.
+        data = projectdata.installed_metadata("pyroma")
+
+        # Verify some key metadata
+        self.assertEqual(data["name"], "pyroma")
+        self.assertEqual(data["summary"], "Test your project's packaging friendliness")
+        self.assertEqual(data["classifier"], [
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
+            "Programming Language :: Python :: 3.14",
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: Implementation :: CPython",
+            "Programming Language :: Python :: Implementation :: PyPy",
+        ])
+        self.assertEqual(data["keywords"], "pypi,quality,testing")
+        self.assertEqual(data["author"], "Lennart Regebro")
+        self.assertEqual(data["author-email"], "regebro@gmail.com")
+        self.assertEqual(data["home-page"], "https://github.com/regebro/pyroma")
+        self.assertEqual(data["license"], "MIT")
+        self.assertEqual(data["license-file"], "LICENSE.txt")
+        self.assertEqual(data["project-url"], "Source Code, https://github.com/regebro/pyroma")
+        self.assertEqual(data["provides-extra"], "test")
+        self.assertEqual(data["requires-python"], "3.9")
+
 
 class DistroDataTest(unittest.TestCase):
     maxDiff = None


### PR DESCRIPTION
Adds a new `pyroma.projectdata.installed_metadata()` API that allows for the extraction and normalisation of project metadata from an *installed* wheel.

Existing APIs for `build_metadata`, `wheel_metadata` et al work great when pyroma is being run on a project directory, as an external check of project metadata compliance. 

However, these mechanisms involve internally calling out to `build` to construct a project's wheel metadata from scratch. This can be problematic for 2 reasons:

1. The test can't be invoked on platforms where subprocess isn't available (iOS, Android and WASM/Emscripten - all of which are Tier 3 Cpython platforms) 
2. From a reproducibility perspective of a CI/release pipeline, it would be preferable to evaluate the Pyroma compliance *of the wheel that has been generated by the release process*, rather than an artefact that was generated independently. In theory, this shouldn't make any difference - the same project configuration *should* generate the same wheel configuration; but in practice, there's no guarantee that this is the case.

This PR adds a new `pyroma.projectdata.installed_metadata()` API that takes the name of an installed package, and extracts the installed project metadata using `importlib.metadata`. In a CI release workflow, a test suite will (usually) be creating and installing a wheel of the project under test, so this new API allows for the extraction and normalization of that metadata, which can then be passed to a pyroma check.

This was previously possible with Pyroma 4.3.3, using the `map_metadata_keys()` method and `importlib.metadata`; however, this method was removed in #112, and the underlying behavior factored into `build_metadata()`. This PR effectively reverses that refactoring, and adds the importlib-based usage as a convenience.

The motivation for this PR comes from Pillow, which [incorporates a Pyroma test into it's test suite](https://github.com/python-pillow/Pillow/blob/main/Tests/test_pyroma.py); however, that test has required modification to support iOS (see python-pillow/Pillow#9030 and python-pillow/Pillow#9116).