### PR TITLE
Fix warnings from docutils and pkg_resources

### DIFF
--- a/pyroma/ratings.py
+++ b/pyroma/ratings.py
@@ -423,7 +423,7 @@ class ValidREST(BaseTest):
         settings = {"warning_stream": stream}
 
         try:
-            publish_parts(source=source, writer_name="html4css1", settings_overrides=settings)
+            publish_parts(source=source, writer="html4css1", settings_overrides=settings)
         except SystemMessage as e:
             self._message = e.args[0]
         errors = stream.getvalue().strip()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ package_dir =
 python_requires = >=3.9
 install_requires =
     build>=0.7.0
-    docutils
+    docutils>=0.22
     packaging
     pygments
     requests


### PR DESCRIPTION
```
pyroma/tests.py:8
  /Users/hugo/github/pyroma/pyroma/tests.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    from pkg_resources import resource_filename, resource_string

pyroma/tests.py: 11 warnings
  /Users/hugo/github/pyroma/pyroma/ratings.py:426: PendingDeprecationWarning: Argument "writer_name" will be removed in Docutils 2.0.  Specify writer name in the "writer" argument.
    publish_parts(source=source, writer_name="html4css1", settings_overrides=settings)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```